### PR TITLE
fix: grant write permissions for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: read  # Required to checkout code
+  contents: write  # Required to checkout code
   pages: write    # Required to deploy to GitHub Pages
   id-token: write # Required to verify deployment authenticity
 


### PR DESCRIPTION
The previous deploy.yml workflow failed to push to the `pages` branch because the workflow only requested read access for contents. This caused the `peaceiris/actions-gh-pages@v3` step to throw a permission error (403) when pushing, resulting in "Permission denied to github-actions[bot]" during deployment.\n\nThis commit updates the workflow permissions to `contents: write`, which grants the GITHUB_TOKEN write access to the repository so the action can push built artifacts to the pages branch. No other logic changes were made.